### PR TITLE
Edgeadc ingress controller test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Go format check
+        run: |
+          UNFORMATTED="$(gofmt -l .)"
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files are not gofmt'd:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+      - name: Go test
+        run: go test ./...
+      - name: Go vet
+        run: go vet ./...
+
+  edgeadc-integration:
+    runs-on: ubuntu-latest
+    env:
+      EDGEADC_IMAGE: ${{ vars.EDGEADC_IMAGE || 'edgeadc:latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to EdgeADC registry (optional)
+        if: ${{ secrets.EDGEADC_REGISTRY_USERNAME != '' && secrets.EDGEADC_REGISTRY_PASSWORD != '' }}
+        env:
+          EDGEADC_REGISTRY_HOST: ${{ vars.EDGEADC_REGISTRY_HOST || 'docker.io' }}
+          EDGEADC_REGISTRY_USERNAME: ${{ secrets.EDGEADC_REGISTRY_USERNAME }}
+          EDGEADC_REGISTRY_PASSWORD: ${{ secrets.EDGEADC_REGISTRY_PASSWORD }}
+        run: |
+          echo "$EDGEADC_REGISTRY_PASSWORD" | docker login "$EDGEADC_REGISTRY_HOST" \
+            -u "$EDGEADC_REGISTRY_USERNAME" --password-stdin
+      - name: EdgeADC integration tests
+        run: ./scripts/test-edgeadc.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For EdgeNEXUS ADC connectivity and runtime behavior, see `internal/configs/` and
 
 - **Open a shell in the ingress container**: `scripts/ingress-bash.sh`
 - **Collect diagnostics/logs**: `scripts/ingress-diag.sh`
+- **Run EdgeADC-backed integration tests**: `scripts/test-edgeadc.sh`
 
 ## Development
 

--- a/manager/t/lib/EdgeTest.pm
+++ b/manager/t/lib/EdgeTest.pm
@@ -10,20 +10,46 @@ sub vars_devops() {
     api_user => 'admin',
     api_pass => 'jetnexus',
     api_host => '127.0.0.1',
+    api_port => 443,
 }
 
 sub vars_developer1() {
     api_user => 'admin',
     api_pass => 'jetnexus',
     api_host => '192.168.2.132',
+    api_port => 443,
+}
+
+sub vars_docker() {
+    api_user => 'admin',
+    api_pass => 'jetnexus',
+    api_host => '127.0.0.1',
+    api_port => 8443,
+}
+
+sub apply_env_overrides(%args) {
+    $args{api_user} = $ENV{EDGE_TEST_API_USER}
+        if defined $ENV{EDGE_TEST_API_USER} && length $ENV{EDGE_TEST_API_USER};
+    $args{api_pass} = $ENV{EDGE_TEST_API_PASS}
+        if defined $ENV{EDGE_TEST_API_PASS} && length $ENV{EDGE_TEST_API_PASS};
+    $args{api_host} = $ENV{EDGE_TEST_API_HOST}
+        if defined $ENV{EDGE_TEST_API_HOST} && length $ENV{EDGE_TEST_API_HOST};
+    $args{api_port} = $ENV{EDGE_TEST_API_PORT}
+        if defined $ENV{EDGE_TEST_API_PORT} && length $ENV{EDGE_TEST_API_PORT};
+
+    return %args;
 }
 
 sub vars() {
     # As per your need, you can add more Edge::CertMgr test environments for
     # tests located in `t/`. Set appropriate value in environment variable
-    # `EDGE_TESTENV`:
-    return vars_devops     if $ENV{EDGE_TEST} eq 'devops';
-    return vars_developer1 if $ENV{EDGE_TEST} eq 'developer1';
+    # `EDGE_TEST` and optionally override credentials with EDGE_TEST_API_* envs.
+    return apply_env_overrides(vars_devops())
+        if $ENV{EDGE_TEST} eq 'devops';
+    return apply_env_overrides(vars_developer1())
+        if $ENV{EDGE_TEST} eq 'developer1';
+    return apply_env_overrides(vars_docker())
+        if $ENV{EDGE_TEST} eq 'docker';
 
     die "Value not supported from EDGE_TEST environment variable: " .
         $ENV{EDGE_TEST}

--- a/scripts/test-edgeadc.sh
+++ b/scripts/test-edgeadc.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+EDGEADC_IMAGE="${EDGEADC_IMAGE:-edgeadc:latest}"
+EDGEADC_CONTAINER_NAME="${EDGEADC_CONTAINER_NAME:-edgeadc-test}"
+EDGEADC_API_HOST="${EDGEADC_API_HOST:-127.0.0.1}"
+EDGEADC_API_PORT="${EDGEADC_API_PORT:-8443}"
+EDGEADC_API_USER="${EDGEADC_API_USER:-admin}"
+EDGEADC_API_PASS="${EDGEADC_API_PASS:-jetnexus}"
+EDGEADC_WAIT_SECONDS="${EDGEADC_WAIT_SECONDS:-60}"
+# Override settings with EDGEADC_* environment variables as needed.
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd curl
+
+cleanup() {
+  docker rm -f "$EDGEADC_CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Starting EdgeADC container ${EDGEADC_CONTAINER_NAME}..."
+docker run -d --rm \
+  --name "$EDGEADC_CONTAINER_NAME" \
+  -p "${EDGEADC_API_PORT}:443" \
+  "$EDGEADC_IMAGE" >/dev/null
+
+echo "Waiting for EdgeADC API on https://${EDGEADC_API_HOST}:${EDGEADC_API_PORT} ..."
+waited=0
+until curl -k -s -o /dev/null "https://${EDGEADC_API_HOST}:${EDGEADC_API_PORT}/"; do
+  waited=$((waited + 1))
+  if [ "$waited" -ge "$EDGEADC_WAIT_SECONDS" ]; then
+    echo "EdgeADC API did not become ready within ${EDGEADC_WAIT_SECONDS}s." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+export EDGE_TEST=docker
+export EDGE_TEST_API_HOST="$EDGEADC_API_HOST"
+export EDGE_TEST_API_PORT="$EDGEADC_API_PORT"
+export EDGE_TEST_API_USER="$EDGEADC_API_USER"
+export EDGE_TEST_API_PASS="$EDGEADC_API_PASS"
+
+if command -v prove >/dev/null 2>&1; then
+  prove -I manager/lib manager/t/test_samples.t
+else
+  perl -I manager/lib manager/t/test_samples.t
+fi


### PR DESCRIPTION
Add a script and configuration to run integration tests against a Docker-hosted EdgeADC instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8224ac9-c161-4cdc-9c5b-4680448fb407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8224ac9-c161-4cdc-9c5b-4680448fb407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces CI automation and a Docker-based harness to run EdgeADC-backed integration tests.
> 
> - Adds GitHub Actions workflow `CI` with Go lint/test (`gofmt`, `go test`, `go vet`) and an `edgeadc-integration` job that optionally logs into a registry and runs `scripts/test-edgeadc.sh`
> - New `scripts/test-edgeadc.sh` spins up `EDGEADC_IMAGE`, waits for the API, exports `EDGE_TEST`/`EDGE_TEST_API_*`, then runs `manager/t/test_samples.t`
> - Enhances `manager/t/lib/EdgeTest.pm` to support a `docker` test profile, default `api_port`, and environment-based overrides
> - Updates `README.md` to document `scripts/test-edgeadc.sh`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fdccba5a9531c6d80606466d1bc2dd0cd395f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->