### PR TITLE
Edgeadc non-numeric wait

### DIFF
--- a/scripts/test-edgeadc.sh
+++ b/scripts/test-edgeadc.sh
@@ -10,6 +10,11 @@ EDGEADC_API_PASS="${EDGEADC_API_PASS:-jetnexus}"
 EDGEADC_WAIT_SECONDS="${EDGEADC_WAIT_SECONDS:-60}"
 # Override settings with EDGEADC_* environment variables as needed.
 
+if ! [[ "$EDGEADC_WAIT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "EDGEADC_WAIT_SECONDS must be a non-negative integer, got '${EDGEADC_WAIT_SECONDS}'." >&2
+  exit 1
+fi
+
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Missing required command: $1" >&2


### PR DESCRIPTION
Add validation for `EDGEADC_WAIT_SECONDS` to prevent an infinite loop when it's non-numeric.

If `EDGEADC_WAIT_SECONDS` is set to a non-numeric value, the integer comparison `[ "$waited" -ge "$EDGEADC_WAIT_SECONDS" ]` fails silently, causing the timeout check to never succeed and resulting in an infinite loop instead of a timeout.

---
<a href="https://cursor.com/background-agent?bcId=bc-880d520e-24dc-4fb9-b923-be28d4482aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-880d520e-24dc-4fb9-b923-be28d4482aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

